### PR TITLE
Fix Popup Numeric Display (clean)

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -345,8 +345,8 @@ class FrontPage(Screen, MakesmithInitFuncs):
         
         '''
         try:
-            float(self.popupContent.textInput.text)
-            self.targetWidget.text = self.popupContent.textInput.text
+            tempfloat = float(self.popupContent.textInput.text)
+            self.targetWidget.text = str(tempfloat)  # Update displayed text using standard numeric format
         except:
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
         self._popup.dismiss()

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -74,8 +74,8 @@ class ZAxisPopupContent(GridLayout):
         
         '''
         try:
-            float(self.popupContent.textInput.text)
-            self.distBtn.text = self.popupContent.textInput.text
+            tempfloat = float(self.popupContent.textInput.text)
+            self.distBtn.text = str(tempfloat)  # Update displayed text using standard numeric format
         except:
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
         self._popup.dismiss()


### PR DESCRIPTION
The number displayed after closing a popup (touchNumberInput or z-Axis Popup) is the text version of what was entered.  If the user enters "000" the number displayed will be "000".  If the user enters ".1" the number displayed will be ".1".
By converting the number to a float and back to a string, we can display the number in standard format.  If the user enters "000" the number displayed will be "0.0".  If the user enters ".1" the number displayed will be "0.1".  (Now trying as clean update to original master.)